### PR TITLE
fix double-counting of intervals contained within bins

### DIFF
--- a/src/AnalysePathBox.fs
+++ b/src/AnalysePathBox.fs
@@ -511,8 +511,9 @@ let computeHistogramForPath (p: ProgramPath) (config: Hyperparameters) =
         let loBin = max 0 loBin
         let hiBin = min (numBins - 1) hiBin
 
-        for i in loBin .. hiBin do
-            result.Histogram.[i] <- result.Histogram.[i] + zeroTo integral.hi
+        if not (loBin = hiBin) then
+          for i in loBin .. hiBin do
+              result.Histogram.[i] <- result.Histogram.[i] + zeroTo integral.hi
 
     printfn $"{result}"
 


### PR DESCRIPTION
With `# method boxes`, no matter what I did, I couldn't get output intervals more precise than a factor of 2 wide. Almost exactly a factor of 2 wide, in fact. Suspicious! I think I tracked down the issue.